### PR TITLE
Add command line log option for easier logging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -53,6 +53,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "ansi_term"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -282,11 +290,16 @@ dependencies = [
 name = "cli"
 version = "0.1.0"
 dependencies = [
+ "ansi_term 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "atty 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "exit-future 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "lp2p 0.1.0",
+ "regex 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "structopt 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1910,6 +1923,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.1.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_syscall 0.1.56 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "tiny-keccak"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2405,6 +2428,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum aesni 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2f70a6b5f971e473091ab7cfb5ffac6cde81666c4556751d8d5620ead8abf100"
 "checksum aho-corasick 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)" = "58fb5e95d83b38284460a5fda7d6470aa0b8844d283a0b614b8535e880800d2d"
 "checksum ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
+"checksum ansi_term 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
 "checksum anyhow 1.0.25 (registry+https://github.com/rust-lang/crates.io-index)" = "9267dff192e68f3399525901e709a48c1d3982c9c072fa32f2127a0cb0babf14"
 "checksum arrayref 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "0d382e583f07208808f6b1249e60848879ba3543f57c32277bf52d69c2f0f0ee"
 "checksum arrayvec 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cff77d8686867eceff3105329d4698d96c2391c176d5d03adc90c7389162b5b8"
@@ -2601,6 +2625,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum termcolor 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)" = "96d6098003bde162e4277c70665bd87c326f5a0c3f3fbfb285787fa482d54e6e"
 "checksum textwrap 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 "checksum thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b"
+"checksum time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "db8dcfca086c1143c9270ac42a2bbd8a7ee477b78ac8e45b19abfb0cbede4b6f"
 "checksum tiny-keccak 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d8a021c69bb74a44ccedb824a046447e2c84a01df9e5c20779750acb38e11b2"
 "checksum tokio 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)" = "5a09c0b5bb588872ab2f09afa13ee6e9dac11e10a0ec9e8e3ba39a5a5d530af6"
 "checksum tokio-codec 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "5c501eceaf96f0e1793cf26beb63da3d11c738c4a943fdf3746d81d64684c39f"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -6,9 +6,15 @@ edition = "2018"
 license = "GPL-3.0"
 
 [dependencies]
-structopt = "0.3"
-tokio = "0.1"
-exit-future = "0.1"
-lp2p = { path = "../lp2p" }
 log = "0.4"
+atty = "0.2"
+time = "0.1.42"
+tokio = "0.1"
+regex = "1.3.1"
+structopt = "0.3"
 env_logger = "0.7.0"
+exit-future = "0.1"
+ansi_term = "0.12.1"
+lazy_static = "1.4.0"
+
+lp2p = { path = "../lp2p" }

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -2,6 +2,12 @@
 
 pub mod cmd;
 
+use std::io::Write;
+
+use ansi_term::Colour;
+use lazy_static::lazy_static;
+use log::info;
+use regex::Regex;
 use structopt::clap::AppSettings;
 use structopt::StructOpt;
 use tokio::runtime::Runtime;
@@ -12,6 +18,10 @@ use self::cmd::Command;
 #[structopt(name = "plum")]
 #[structopt(setting = AppSettings::ArgRequiredElseHelp)]
 pub struct Plum {
+    /// Set a custom logging filter.
+    #[structopt(short = "l", long = "log", value_name = "LOG_PATTERN")]
+    pub log: Option<String>,
+
     #[structopt(subcommand)]
     pub cmd: Command,
 }
@@ -26,7 +36,6 @@ impl Plum {
 }
 
 pub fn run_lp2p(peer_ip: Option<String>) {
-    env_logger::init();
     let (exit_send, exit) = exit_future::signal();
     let mut runtime = Runtime::new().expect("failed to start runtime on current thread");
     let task_executor = runtime.executor();
@@ -36,12 +45,93 @@ pub fn run_lp2p(peer_ip: Option<String>) {
     exit_send.fire();
 }
 
+fn kill_color(s: &str) -> String {
+    lazy_static! {
+        static ref RE: Regex = Regex::new("\x1b\\[[^m]+m").expect("Error initializing color regex");
+    }
+    RE.replace_all(s, "").to_string()
+}
+
+fn init_logger(custom_log: Option<String>) {
+    let mut builder = env_logger::Builder::new();
+    // Disable info logging by default for some modules:
+    builder.filter(Some("ws"), log::LevelFilter::Off);
+    builder.filter(Some("hyper"), log::LevelFilter::Warn);
+    // Enable info for others.
+    builder.filter(None, log::LevelFilter::Info);
+
+    if let Ok(lvl) = std::env::var("RUST_LOG") {
+        builder.parse_filters(&lvl);
+    }
+
+    let pattern = custom_log.as_ref().map(|v| v.as_ref()).unwrap_or("");
+    builder.parse_filters(pattern);
+    let isatty = atty::is(atty::Stream::Stderr);
+    let enable_color = isatty;
+
+    builder.format(move |buf, record| {
+        let now = time::now();
+        let timestamp =
+            time::strftime("%Y-%m-%d %H:%M:%S", &now).expect("Error formatting log timestamp");
+
+        let mut output = if custom_log.is_none() {
+            format!(
+                "{} {}",
+                Colour::RGB(96, 96, 96).paint(timestamp),
+                record.args()
+            )
+        } else if log::max_level() <= log::LevelFilter::Info {
+            format!(
+                "{} {} {} {}",
+                Colour::RGB(96, 96, 96).paint(timestamp),
+                Colour::Yellow.paint(format!("{}", record.level())),
+                record.target(),
+                record.args()
+            )
+        } else {
+            let name = ::std::thread::current()
+                .name()
+                .map_or_else(Default::default, |x| {
+                    format!("{}", Colour::Blue.bold().paint(x))
+                });
+            let millis = (now.tm_nsec as f32 / 1_000_000.0).round() as usize;
+            let timestamp = format!("{}.{:03}", timestamp, millis);
+            format!(
+                "{} {} {} {}  {}",
+                Colour::RGB(96, 96, 96).paint(timestamp),
+                name,
+                Colour::Yellow.paint(format!("{}", record.level())),
+                record.target(),
+                record.args()
+            )
+        };
+
+        if !isatty && record.level() <= log::Level::Info && atty::is(atty::Stream::Stdout) {
+            // duplicate INFO/WARN output to console
+            println!("{}", output);
+        }
+
+        if !enable_color {
+            output = kill_color(output.as_ref());
+        }
+
+        writeln!(buf, "{}", output)
+    });
+
+    if builder.try_init().is_err() {
+        info!("Not registering Plum logger, as there is already a global logger registered!");
+    }
+}
+
 pub fn run() {
     let args = std::env::args().collect::<Vec<String>>();
+
     if args.len() == 1 {
+        init_logger(Some("".into()));
         run_lp2p(None);
     } else {
         let plum = Plum::from_iter(args.iter());
+        init_logger(plum.log.clone());
         plum.execute();
     }
 }

--- a/lp2p/src/lib.rs
+++ b/lp2p/src/lib.rs
@@ -1,13 +1,11 @@
 // Copyright 2019 PolkaX Authors. Licensed under GPL-3.0.
 
-#[macro_use]
-extern crate log;
-
 mod behaviour;
 mod config;
 
 use futures::prelude::*;
 use libp2p::{core::Multiaddr, Swarm};
+use log::info;
 use tokio::runtime::TaskExecutor;
 
 #[derive(Debug, Clone, Default)]


### PR DESCRIPTION
- Add `--log` command line option.
   - No `--log` option: show timestamp.
   - `--log=info`: show timestamp, log level, log target.
   - `--log=any_level_higher_than_info`: show timestamp, thread name, log level, log target.
- Fix partial linter warnings.