### PR TITLE
Improve VRF

### DIFF
--- a/crypto/src/vrf.rs
+++ b/crypto/src/vrf.rs
@@ -3,14 +3,94 @@
 use plum_address::{Address, Protocol};
 use plum_hashing::sha256;
 
+use crate::errors::CryptoError;
+
 /// The bls public key for verifying VRF.
-pub type VrfPublicKey = bls::PublicKey;
+#[derive(Copy, Clone, PartialEq, Debug)]
+pub struct VrfPublicKey(bls::PublicKey);
+
+impl VrfPublicKey {
+    /// Unwrap the VRF public key to the bls public key.
+    pub fn into_inner(self) -> bls::PublicKey {
+        self.0
+    }
+
+    /// Create the VRF public key from the raw bytes.
+    pub fn from_bytes<T: AsRef<[u8]>>(raw: T) -> Result<Self, CryptoError> {
+        use bls::Serialize;
+        Ok(VrfPublicKey(bls::PublicKey::from_bytes(raw.as_ref())?))
+    }
+
+    /// Return a byte slice of this `VRF public key`'s contents.
+    pub fn as_bytes(&self) -> Vec<u8> {
+        use bls::Serialize;
+        self.0.as_bytes()
+    }
+}
+
+impl From<bls::PublicKey> for VrfPublicKey {
+    fn from(bls_pubkey: bls::PublicKey) -> Self {
+        VrfPublicKey(bls_pubkey)
+    }
+}
 
 /// The bls private key for computing VRF.
-pub type VrfPrivateKey = bls::PrivateKey;
+#[derive(Copy, Clone, PartialEq, Debug)]
+pub struct VrfPrivateKey(bls::PrivateKey);
+
+impl VrfPrivateKey {
+    /// Unwrap the VRF private key to the bls private key.
+    pub fn into_inner(self) -> bls::PrivateKey {
+        self.0
+    }
+
+    /// Create the VRF private key from the raw bytes.
+    pub fn from_bytes<T: AsRef<[u8]>>(raw: T) -> Result<Self, CryptoError> {
+        use bls::Serialize;
+        Ok(VrfPrivateKey(bls::PrivateKey::from_bytes(raw.as_ref())?))
+    }
+
+    /// Return a byte slice of this `VRF private key`'s contents.
+    pub fn as_bytes(&self) -> Vec<u8> {
+        use bls::Serialize;
+        self.0.as_bytes()
+    }
+}
+
+impl From<bls::PrivateKey> for VrfPrivateKey {
+    fn from(bls_privkey: bls::PrivateKey) -> Self {
+        VrfPrivateKey(bls_privkey)
+    }
+}
 
 /// The bls signature.
-pub type VrfProof = bls::Signature;
+#[derive(Copy, Clone, PartialEq, Debug)]
+pub struct VrfProof(bls::Signature);
+
+impl VrfProof {
+    /// Unwrap the VRF proof key to the bls signature.
+    pub fn into_inner(self) -> bls::Signature {
+        self.0
+    }
+
+    /// Create the VRF proof from the raw bytes.
+    pub fn from_bytes<T: AsRef<[u8]>>(raw: T) -> Result<Self, CryptoError> {
+        use bls::Serialize;
+        Ok(VrfProof(bls::Signature::from_bytes(raw.as_ref())?))
+    }
+
+    /// Return a byte slice of this `VRF proof`'s contents.
+    pub fn as_bytes(&self) -> Vec<u8> {
+        use bls::Serialize;
+        self.0.as_bytes()
+    }
+}
+
+impl From<bls::Signature> for VrfProof {
+    fn from(bls_signature: bls::Signature) -> Self {
+        VrfProof(bls_signature)
+    }
+}
 
 /// Computing VRF with the given bls private key and VRF params(miner address must be ID address).
 ///
@@ -25,8 +105,8 @@ where
     M: AsRef<[u8]>,
 {
     let msg = hash_vrf_base(personalization, msg, miner);
-    let signature = privkey.sign(msg);
-    signature
+    let signature = privkey.0.sign(msg);
+    VrfProof(signature)
 }
 
 /// Verify VRF with the given bls public key, VRF params(miner address must be ID address)
@@ -47,7 +127,7 @@ where
     // When signing with bls privkey, the message will be hashed in `bls::PrivateKey::sign`,
     // so the message here needs to be hashed before the signature is verified.
     let hashed_msg = bls::hash(msg.as_ref());
-    bls::verify(&proof, &[hashed_msg], &[*pubkey])
+    bls::verify(&proof.0, &[hashed_msg], &[pubkey.0])
 }
 
 fn hash_vrf_base<M>(personalization: u64, msg: M, miner: &Address) -> [u8; 32]


### PR DESCRIPTION
Signed-off-by: koushiro <koushiro.cqx@gmail.com>

* Wrap `bls::PublicKey`, `bls::PrivateKey` and `bls::Signature`
* Add `into_inner`, `from_bytes` and `as_bytes` for `VrfPublicKey`, `VrfPrivateKey` and `VrfProof`.