### PR TITLE
Improve plum_crypto

### DIFF
--- a/crypto/src/signature/mod.rs
+++ b/crypto/src/signature/mod.rs
@@ -85,7 +85,7 @@ impl Signature {
         M: AsRef<[u8]>,
     {
         match ty {
-            SignatureType::Secp256k1 => Self::sign_secp2526k1(privkey, msg),
+            SignatureType::Secp256k1 => Self::sign_secp256k1(privkey, msg),
             SignatureType::Bls => Self::sign_bls(privkey, msg),
         }
     }
@@ -93,7 +93,7 @@ impl Signature {
     /// Sign the message with the given secp256k1 private key.
     ///
     /// Return the secp256k1 signature.
-    pub fn sign_secp2526k1<K, M>(privkey: K, msg: M) -> Result<Self, CryptoError>
+    pub fn sign_secp256k1<K, M>(privkey: K, msg: M) -> Result<Self, CryptoError>
     where
         K: AsRef<[u8]>,
         M: AsRef<[u8]>,
@@ -187,7 +187,7 @@ mod tests {
         let pubkey = PublicKey::from_privkey(&privkey);
         let (privkey, pubkey) = (privkey.into_vec(), pubkey.into_vec());
         let msg = "hello, world";
-        let signature = Signature::sign_secp2526k1(privkey, msg).unwrap();
+        let signature = Signature::sign_secp256k1(privkey, msg).unwrap();
         let res = signature.verify_secp256k1(pubkey, msg);
         assert_eq!(res, Ok(true))
     }

--- a/primitives/address/src/address.rs
+++ b/primitives/address/src/address.rs
@@ -92,6 +92,16 @@ impl Address {
         &self.payload
     }
 
+    /// Return the actual public key of the address.
+    pub fn pubkey(&self) -> Result<&[u8], AddressError> {
+        match self.protocol() {
+            Protocol::ID => Err(AddressError::UnknownPublicKey),
+            Protocol::SECP256K1 => Ok(self.payload()),
+            Protocol::Actor => Err(AddressError::UnknownPublicKey),
+            Protocol::BLS => Ok(self.payload())
+        }
+    }
+
     /// Return the encoded bytes of address (protocol + payload).
     pub fn as_bytes(&self) -> Vec<u8> {
         let mut bytes = Vec::with_capacity(1 + self.payload.len());

--- a/primitives/address/src/errors.rs
+++ b/primitives/address/src/errors.rs
@@ -16,6 +16,9 @@ pub enum AddressError {
     /// Unknown address protocol.
     #[error("Unknown protocol")]
     UnknownProtocol,
+    /// Unknown public key type.
+    #[error("Unknown public key type")]
+    UnknownPublicKey,
     /// Invalid address payload.
     #[error("Invalid address payload")]
     InvalidPayload,

--- a/primitives/address/src/protocol.rs
+++ b/primitives/address/src/protocol.rs
@@ -38,8 +38,19 @@ impl convert::TryFrom<u8> for Protocol {
     }
 }
 
+impl From<Protocol> for u8 {
+    fn from(protocol: Protocol) -> Self {
+        match protocol {
+            Protocol::ID => 0,
+            Protocol::SECP256K1 => 1,
+            Protocol::Actor => 2,
+            Protocol::BLS => 3,
+        }
+    }
+}
+
 impl fmt::Display for Protocol {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", *self as u8)
+        write!(f, "{}", u8::from(*self))
     }
 }


### PR DESCRIPTION
* Add pubkey method for Address
* Impl From<Protocol> for u8
* Fix typo (sign_secp2526k1 => sign_secp256k1)

Signed-off-by: koushiro <koushiro.cqx@gmail.com>