### PR TITLE
Improve serializtion/deserializaion of some types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -332,7 +332,7 @@ checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 [[package]]
 name = "cid"
 version = "0.4.0"
-source = "git+https://github.com/PolkaX/rust-cid?branch=impl-serde#82138c7edf9eb3b3f2c0fd4fe1bfa3bf86dec611"
+source = "git+https://github.com/PolkaX/rust-cid?branch=impl-serde#347e0f910454bf0148a6143ba7f760f62b6d72f3"
 dependencies = [
  "multibase",
  "multihash",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2190,11 +2190,11 @@ dependencies = [
 name = "plum_crypto"
 version = "0.1.0"
 dependencies = [
- "base64 0.12.0",
  "bls-signatures",
  "libsecp256k1",
  "plum_address",
  "plum_hashing",
+ "plum_types",
  "rand 0.7.3",
  "serde",
  "serde_bytes",
@@ -2247,12 +2247,12 @@ dependencies = [
 name = "plum_message"
 version = "0.1.0"
 dependencies = [
- "base64 0.12.0",
  "cid 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "multihash",
  "plum_address",
  "plum_bigint",
  "plum_crypto",
+ "plum_types",
  "serde",
  "serde_bytes",
  "serde_cbor 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2282,7 +2282,7 @@ dependencies = [
 name = "plum_ticket"
 version = "0.1.0"
 dependencies = [
- "base64 0.12.0",
+ "plum_types",
  "serde",
  "serde_bytes",
  "serde_cbor 0.11.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2311,6 +2311,7 @@ dependencies = [
 name = "plum_types"
 version = "0.1.0"
 dependencies = [
+ "base64 0.12.0",
  "cid 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "plum_bigint",
  "serde",
@@ -2328,12 +2329,12 @@ dependencies = [
 name = "plum_wallet"
 version = "0.1.0"
 dependencies = [
- "base64 0.12.0",
  "bls-signatures",
  "libsecp256k1",
  "parking_lot 0.10.2",
  "plum_address",
  "plum_crypto",
+ "plum_types",
  "rand 0.7.3",
  "serde",
  "serde_json",

--- a/chain/actor/src/abi/bitfield.rs
+++ b/chain/actor/src/abi/bitfield.rs
@@ -5,7 +5,7 @@ use codec_rle::{rle_decode, rle_encode};
 use serde::{de::Error, Deserialize, Deserializer, Serialize, Serializer};
 use std::borrow::{Borrow, BorrowMut};
 
-#[derive(Debug, Clone, Eq, PartialEq)]
+#[derive(Debug, Clone, Eq, PartialEq, Default)]
 pub struct BitField(BTreeSet<u64>);
 
 impl BitField {

--- a/chain/actor/src/builtin/market/actor.rs
+++ b/chain/actor/src/builtin/market/actor.rs
@@ -44,7 +44,7 @@ impl StorageDealProposal {
             return Err(StorageMarketError::AlreadySigned);
         }
         // todo why use an empty bytes?
-        let sign = sign_func(&vec![]);
+        let sign = sign_func(&[]);
         self.proposer_signature = Some(sign);
         Ok(())
     }

--- a/chain/actor/src/builtin/miner/state.rs
+++ b/chain/actor/src/builtin/miner/state.rs
@@ -2,9 +2,7 @@ use serde_tuple::{Deserialize_tuple, Serialize_tuple};
 
 use cid::Cid;
 use plum_address::Address;
-use plum_types::{
-    chain_epoch::ChainEpoch, DealId, DealWeight, PeerId, SectorNumber, SectorSize, TokenAmount,
-};
+use plum_types::{ChainEpoch, DealId, DealWeight, PeerId, SectorNumber, SectorSize, TokenAmount};
 
 use crate::abi::bitfield::BitField;
 

--- a/chain/actor/src/builtin/miner/tests.rs
+++ b/chain/actor/src/builtin/miner/tests.rs
@@ -6,10 +6,7 @@ use cid::Cid;
 use hex_literal::hex;
 use plum_address::Address;
 
-use super::actor::*;
 use super::state::*;
-use super::*;
-
 use crate::abi::bitfield::BitField;
 use crate::abi::sector::RegisteredProof;
 
@@ -45,7 +42,6 @@ fn miner_info2() -> MinerInfo {
 
 #[test]
 fn test_cbor_mineractorstate() {
-    let c = Cid::try_from(hex!("015501020001").as_ref()).unwrap();
     let mut bitfield = BitField::new();
     bitfield.insert(2);
     bitfield.insert(7);

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -6,7 +6,6 @@ edition = "2018"
 license = "GPL-3.0"
 
 [dependencies]
-base64 = "0.12"
 bls-signatures = "0.5"
 libsecp256k1 = "0.3"
 rand = "0.7"
@@ -16,6 +15,7 @@ thiserror = "1.0"
 
 plum_address = { path = "../primitives/address" }
 plum_hashing = { path = "../hashing" }
+plum_types = { path = "../primitives/types" }
 
 [dev-dependencies]
 serde_cbor = "0.11"

--- a/crypto/src/signature/mod.rs
+++ b/crypto/src/signature/mod.rs
@@ -14,6 +14,7 @@ use crate::errors::CryptoError;
 pub const SIGNATURE_MAX_LENGTH: u32 = 200;
 
 /// The signature type.
+#[repr(u8)]
 #[derive(Eq, PartialEq, Debug, Clone, Copy, Hash)]
 pub enum SignatureType {
     /// The `Secp256k1` signature.

--- a/crypto/src/signature/mod.rs
+++ b/crypto/src/signature/mod.rs
@@ -54,28 +54,28 @@ impl From<SignatureType> for u8 {
 #[derive(Eq, PartialEq, Debug, Clone, Hash)]
 pub struct Signature {
     /// The signature type.
-    ty: SignatureType,
+    r#type: SignatureType,
     /// Tha actual signature bytes.
-    bytes: Vec<u8>,
+    data: Vec<u8>,
 }
 
 impl Signature {
-    /// Create a signature with the given type and raw bytes
-    pub fn new<T: Into<Vec<u8>>>(ty: SignatureType, bytes: T) -> Self {
+    /// Create a signature with the given type and raw data
+    pub fn new<T: Into<Vec<u8>>>(ty: SignatureType, data: T) -> Self {
         Self {
-            ty,
-            bytes: bytes.into(),
+            r#type: ty,
+            data: data.into(),
         }
     }
 
-    /// Create a Secp256k1 signature with the given raw bytes.
-    pub fn new_secp256k1<T: Into<Vec<u8>>>(bytes: T) -> Self {
-        Self::new(SignatureType::Secp256k1, bytes)
+    /// Create a Secp256k1 signature with the given raw data.
+    pub fn new_secp256k1<T: Into<Vec<u8>>>(data: T) -> Self {
+        Self::new(SignatureType::Secp256k1, data)
     }
 
-    /// Create a `BLS` signature with the given raw bytes.
-    pub fn new_bls<T: Into<Vec<u8>>>(bytes: T) -> Self {
-        Self::new(SignatureType::Bls, bytes)
+    /// Create a `BLS` signature with the given raw data.
+    pub fn new_bls<T: Into<Vec<u8>>>(data: T) -> Self {
+        Self::new(SignatureType::Bls, data)
     }
 
     /// Sign the message with the given signature type and private key.
@@ -105,8 +105,8 @@ impl Signature {
         let message = secp256k1::Message::parse(&hashed_msg);
         let (signature, _recovery_id) = secp256k1::sign(&message, &seckey);
         Ok(Self {
-            ty: SignatureType::Secp256k1,
-            bytes: signature.serialize().to_vec(),
+            r#type: SignatureType::Secp256k1,
+            data: signature.serialize().to_vec(),
         })
     }
 
@@ -122,8 +122,8 @@ impl Signature {
         let privkey = bls::PrivateKey::from_bytes(privkey.as_ref())?;
         let signature = privkey.sign(msg);
         Ok(Self {
-            ty: SignatureType::Bls,
-            bytes: signature.as_bytes(),
+            r#type: SignatureType::Bls,
+            data: signature.as_bytes(),
         })
     }
 
@@ -133,7 +133,7 @@ impl Signature {
         K: AsRef<[u8]>,
         M: AsRef<[u8]>,
     {
-        match self.ty {
+        match self.r#type {
             SignatureType::Secp256k1 => self.verify_secp256k1(pubkey, msg),
             SignatureType::Bls => self.verify_bls(pubkey, msg),
         }
@@ -148,7 +148,7 @@ impl Signature {
         let pubkey = secp256k1::PublicKey::parse_slice(pubkey.as_ref(), None)?;
         let hashed_msg = blake2b_256(msg);
         let msg = secp256k1::Message::parse(&hashed_msg); //  secp256k1::util::MESSAGE_SIZE == 32 bytes
-        let signature = secp256k1::Signature::parse_slice(&self.bytes)?;
+        let signature = secp256k1::Signature::parse_slice(&self.data)?;
         Ok(secp256k1::verify(&msg, &signature, &pubkey))
     }
 
@@ -163,32 +163,32 @@ impl Signature {
         // When signing with `BLS` privkey, the message will be hashed in `bls::PrivateKey::sign`,
         // so the message here needs to be hashed before the signature is verified.
         let hashed_msg = bls::hash(msg.as_ref());
-        let signature = bls::Signature::from_bytes(&self.bytes)?;
+        let signature = bls::Signature::from_bytes(&self.data)?;
         Ok(bls::verify(&signature, &[hashed_msg], &[pubkey]))
     }
 
     /// Return the signature type.
     pub fn r#type(&self) -> SignatureType {
-        self.ty
+        self.r#type
     }
 
     /// Return the actual signature bytes.
     pub fn as_bytes(&self) -> &[u8] {
-        self.bytes.as_slice()
+        self.data.as_slice()
     }
 
     /// helper function to check signture type is same with address type
     pub fn check_address_type(&self, addr: &Address) -> Result<(), CryptoError> {
         let protocol = addr.protocol();
-        match self.ty {
+        match self.r#type {
             SignatureType::Secp256k1 => {
                 if protocol != Protocol::Secp256k1 {
-                    return Err(CryptoError::NotSameType(self.ty, protocol));
+                    return Err(CryptoError::NotSameType(self.r#type, protocol));
                 }
             }
             SignatureType::Bls => {
                 if protocol != Protocol::Bls {
-                    return Err(CryptoError::NotSameType(self.ty, protocol));
+                    return Err(CryptoError::NotSameType(self.r#type, protocol));
                 }
             }
         }

--- a/crypto/src/signature/serde.rs
+++ b/crypto/src/signature/serde.rs
@@ -90,10 +90,9 @@ pub mod json {
     use crate::signature::{Signature, SignatureType};
 
     #[derive(Clone, Copy, Serialize, Deserialize)]
+    #[serde(rename_all = "lowercase")]
     enum JsonSignatureType {
-        #[serde(rename = "secp256k1")]
         Secp256k1,
-        #[serde(rename = "bls")]
         Bls,
     }
 

--- a/primitives/block/src/block.rs
+++ b/primitives/block/src/block.rs
@@ -13,9 +13,9 @@ pub struct Block {
     /// The block header.
     pub header: BlockHeader,
     /// The `BLS` messages.
-    pub bls_msgs: Vec<UnsignedMessage>,
+    pub bls_messages: Vec<UnsignedMessage>,
     /// The `Secp256k1` messages.
-    pub secp_msgs: Vec<SignedMessage>,
+    pub secpk_messages: Vec<SignedMessage>,
 }
 
 impl Block {
@@ -73,12 +73,12 @@ pub mod cbor {
         CborBlockRef(
             &block.header,
             &block
-                .bls_msgs
+                .bls_messages
                 .iter()
                 .map(|bls_msg| CborUnsignedMessageRef(bls_msg))
                 .collect::<Vec<_>>(),
             &block
-                .secp_msgs
+                .secpk_messages
                 .iter()
                 .map(|secp_msg| CborSignedMessageRef(secp_msg))
                 .collect::<Vec<_>>(),
@@ -102,11 +102,11 @@ pub mod cbor {
     where
         D: de::Deserializer<'de>,
     {
-        let CborBlock(header, bls_msgs, secp_msgs) = CborBlock::deserialize(deserializer)?;
+        let CborBlock(header, bls_msgs, secpk_msgs) = CborBlock::deserialize(deserializer)?;
         Ok(Block {
             header,
-            bls_msgs: bls_msgs.into_iter().map(|bls_msg| bls_msg.0).collect(),
-            secp_msgs: secp_msgs.into_iter().map(|secp_msg| secp_msg.0).collect(),
+            bls_messages: bls_msgs.into_iter().map(|bls_msg| bls_msg.0).collect(),
+            secpk_messages: secpk_msgs.into_iter().map(|secp_msg| secp_msg.0).collect(),
         })
     }
 }
@@ -127,14 +127,12 @@ pub mod json {
     #[derive(Serialize)]
     struct JsonSignedMessageRef<'a>(#[serde(with = "signed_message_json")] &'a SignedMessage);
     #[derive(Serialize)]
+    #[serde(rename_all = "PascalCase")]
     struct JsonBlockRef<'a> {
-        #[serde(rename = "Header")]
         #[serde(with = "crate::header::json")]
         header: &'a BlockHeader,
-        #[serde(rename = "BlsMessages")]
-        bls_msgs: &'a [JsonUnsignedMessageRef<'a>],
-        #[serde(rename = "SecpkMessages")]
-        secp_msgs: &'a [JsonSignedMessageRef<'a>],
+        bls_messages: &'a [JsonUnsignedMessageRef<'a>],
+        secpk_messages: &'a [JsonSignedMessageRef<'a>],
     }
 
     /// JSON serialization
@@ -144,15 +142,15 @@ pub mod json {
     {
         JsonBlockRef {
             header: &block.header,
-            bls_msgs: &block
-                .bls_msgs
+            bls_messages: &block
+                .bls_messages
                 .iter()
                 .map(|bls_msg| JsonUnsignedMessageRef(bls_msg))
                 .collect::<Vec<_>>(),
-            secp_msgs: &block
-                .secp_msgs
+            secpk_messages: &block
+                .secpk_messages
                 .iter()
-                .map(|secp_msg| JsonSignedMessageRef(secp_msg))
+                .map(|secpk_msg| JsonSignedMessageRef(secpk_msg))
                 .collect::<Vec<_>>(),
         }
         .serialize(serializer)
@@ -163,14 +161,12 @@ pub mod json {
     #[derive(Deserialize)]
     struct JsonSignedMessage(#[serde(with = "signed_message_json")] SignedMessage);
     #[derive(Deserialize)]
+    #[serde(rename_all = "PascalCase")]
     struct JsonBlock {
-        #[serde(rename = "Header")]
         #[serde(with = "crate::header::json")]
         header: BlockHeader,
-        #[serde(rename = "BlsMessages")]
-        bls_msgs: Vec<JsonUnsignedMessage>,
-        #[serde(rename = "SecpkMessages")]
-        secp_msgs: Vec<JsonSignedMessage>,
+        bls_messages: Vec<JsonUnsignedMessage>,
+        secpk_messages: Vec<JsonSignedMessage>,
     }
 
     /// JSON deserialization
@@ -180,13 +176,13 @@ pub mod json {
     {
         let JsonBlock {
             header,
-            bls_msgs,
-            secp_msgs,
+            bls_messages: bls_msgs,
+            secpk_messages: secp_msgs,
         } = JsonBlock::deserialize(deserializer)?;
         Ok(Block {
             header,
-            bls_msgs: bls_msgs.into_iter().map(|bls_msg| bls_msg.0).collect(),
-            secp_msgs: secp_msgs.into_iter().map(|secp_msg| secp_msg.0).collect(),
+            bls_messages: bls_msgs.into_iter().map(|bls_msg| bls_msg.0).collect(),
+            secpk_messages: secp_msgs.into_iter().map(|secpk_msg| secpk_msg.0).collect(),
         })
     }
 }

--- a/primitives/block/src/block.rs
+++ b/primitives/block/src/block.rs
@@ -55,14 +55,10 @@ pub mod cbor {
     use crate::header::BlockHeader;
 
     #[derive(Serialize)]
-    struct CborUnsignedMessageRef<'a>(#[serde(with = "unsigned_message_cbor")] &'a UnsignedMessage);
-    #[derive(Serialize)]
-    struct CborSignedMessageRef<'a>(#[serde(with = "signed_message_cbor")] &'a SignedMessage);
-    #[derive(Serialize)]
     struct CborBlockRef<'a>(
         #[serde(with = "crate::header::cbor")] &'a BlockHeader,
-        &'a [CborUnsignedMessageRef<'a>],
-        &'a [CborSignedMessageRef<'a>],
+        #[serde(with = "unsigned_message_cbor::vec")] &'a [UnsignedMessage],
+        #[serde(with = "signed_message_cbor::vec")] &'a [SignedMessage],
     );
 
     /// CBOR serialization
@@ -70,31 +66,15 @@ pub mod cbor {
     where
         S: ser::Serializer,
     {
-        CborBlockRef(
-            &block.header,
-            &block
-                .bls_messages
-                .iter()
-                .map(|bls_msg| CborUnsignedMessageRef(bls_msg))
-                .collect::<Vec<_>>(),
-            &block
-                .secpk_messages
-                .iter()
-                .map(|secp_msg| CborSignedMessageRef(secp_msg))
-                .collect::<Vec<_>>(),
-        )
-        .serialize(serializer)
+        CborBlockRef(&block.header, &block.bls_messages, &block.secpk_messages)
+            .serialize(serializer)
     }
 
     #[derive(Deserialize)]
-    struct CborUnsignedMessage(#[serde(with = "unsigned_message_cbor")] UnsignedMessage);
-    #[derive(Deserialize)]
-    struct CborSignedMessage(#[serde(with = "signed_message_cbor")] SignedMessage);
-    #[derive(Deserialize)]
     struct CborBlock(
         #[serde(with = "crate::header::cbor")] BlockHeader,
-        Vec<CborUnsignedMessage>,
-        Vec<CborSignedMessage>,
+        #[serde(with = "unsigned_message_cbor::vec")] Vec<UnsignedMessage>,
+        #[serde(with = "signed_message_cbor::vec")] Vec<SignedMessage>,
     );
 
     /// CBOR deserialization
@@ -102,11 +82,11 @@ pub mod cbor {
     where
         D: de::Deserializer<'de>,
     {
-        let CborBlock(header, bls_msgs, secpk_msgs) = CborBlock::deserialize(deserializer)?;
+        let CborBlock(header, bls_messages, secpk_messages) = CborBlock::deserialize(deserializer)?;
         Ok(Block {
             header,
-            bls_messages: bls_msgs.into_iter().map(|bls_msg| bls_msg.0).collect(),
-            secpk_messages: secpk_msgs.into_iter().map(|secp_msg| secp_msg.0).collect(),
+            bls_messages,
+            secpk_messages,
         })
     }
 }
@@ -123,16 +103,14 @@ pub mod json {
     use crate::header::BlockHeader;
 
     #[derive(Serialize)]
-    struct JsonUnsignedMessageRef<'a>(#[serde(with = "unsigned_message_json")] &'a UnsignedMessage);
-    #[derive(Serialize)]
-    struct JsonSignedMessageRef<'a>(#[serde(with = "signed_message_json")] &'a SignedMessage);
-    #[derive(Serialize)]
     #[serde(rename_all = "PascalCase")]
     struct JsonBlockRef<'a> {
         #[serde(with = "crate::header::json")]
         header: &'a BlockHeader,
-        bls_messages: &'a [JsonUnsignedMessageRef<'a>],
-        secpk_messages: &'a [JsonSignedMessageRef<'a>],
+        #[serde(with = "unsigned_message_json::vec")]
+        bls_messages: &'a [UnsignedMessage],
+        #[serde(with = "signed_message_json::vec")]
+        secpk_messages: &'a [SignedMessage],
     }
 
     /// JSON serialization
@@ -142,31 +120,21 @@ pub mod json {
     {
         JsonBlockRef {
             header: &block.header,
-            bls_messages: &block
-                .bls_messages
-                .iter()
-                .map(|bls_msg| JsonUnsignedMessageRef(bls_msg))
-                .collect::<Vec<_>>(),
-            secpk_messages: &block
-                .secpk_messages
-                .iter()
-                .map(|secpk_msg| JsonSignedMessageRef(secpk_msg))
-                .collect::<Vec<_>>(),
+            bls_messages: &block.bls_messages,
+            secpk_messages: &block.secpk_messages,
         }
         .serialize(serializer)
     }
 
     #[derive(Deserialize)]
-    struct JsonUnsignedMessage(#[serde(with = "unsigned_message_json")] UnsignedMessage);
-    #[derive(Deserialize)]
-    struct JsonSignedMessage(#[serde(with = "signed_message_json")] SignedMessage);
-    #[derive(Deserialize)]
     #[serde(rename_all = "PascalCase")]
     struct JsonBlock {
         #[serde(with = "crate::header::json")]
         header: BlockHeader,
-        bls_messages: Vec<JsonUnsignedMessage>,
-        secpk_messages: Vec<JsonSignedMessage>,
+        #[serde(with = "unsigned_message_json::vec")]
+        bls_messages: Vec<UnsignedMessage>,
+        #[serde(with = "signed_message_json::vec")]
+        secpk_messages: Vec<SignedMessage>,
     }
 
     /// JSON deserialization
@@ -176,13 +144,13 @@ pub mod json {
     {
         let JsonBlock {
             header,
-            bls_messages: bls_msgs,
-            secpk_messages: secp_msgs,
+            bls_messages,
+            secpk_messages,
         } = JsonBlock::deserialize(deserializer)?;
         Ok(Block {
             header,
-            bls_messages: bls_msgs.into_iter().map(|bls_msg| bls_msg.0).collect(),
-            secpk_messages: secp_msgs.into_iter().map(|secpk_msg| secpk_msg.0).collect(),
+            bls_messages,
+            secpk_messages,
         })
     }
 }

--- a/primitives/block/src/block_msg.rs
+++ b/primitives/block/src/block_msg.rs
@@ -11,9 +11,9 @@ pub struct BlockMsg {
     /// The block header.
     pub header: BlockHeader,
     /// The CIDs of `BLS` messages.
-    pub bls_msgs: Vec<Cid>,
+    pub bls_messages: Vec<Cid>,
     /// The CIDs of `Secp256k1` messages.
-    pub secp_msgs: Vec<Cid>,
+    pub secpk_messages: Vec<Cid>,
 }
 
 impl BlockMsg {
@@ -66,12 +66,12 @@ pub mod cbor {
         CborBlockMsgRef(
             &block.header,
             &block
-                .bls_msgs
+                .bls_messages
                 .iter()
                 .map(|cid| CborCidRef(cid))
                 .collect::<Vec<_>>(),
             &block
-                .secp_msgs
+                .secpk_messages
                 .iter()
                 .map(|cid| CborCidRef(cid))
                 .collect::<Vec<_>>(),
@@ -93,11 +93,11 @@ pub mod cbor {
     where
         D: de::Deserializer<'de>,
     {
-        let CborBlockMsg(header, bls_msgs, secp_msgs) = CborBlockMsg::deserialize(deserializer)?;
+        let CborBlockMsg(header, bls_msgs, secpk_msgs) = CborBlockMsg::deserialize(deserializer)?;
         Ok(BlockMsg {
             header,
-            bls_msgs: bls_msgs.into_iter().map(|cid| cid.0).collect(),
-            secp_msgs: secp_msgs.into_iter().map(|cid| cid.0).collect(),
+            bls_messages: bls_msgs.into_iter().map(|cid| cid.0).collect(),
+            secpk_messages: secpk_msgs.into_iter().map(|cid| cid.0).collect(),
         })
     }
 }
@@ -113,14 +113,12 @@ pub mod json {
     #[derive(Serialize)]
     struct JsonCidRef<'a>(#[serde(with = "cid::ipld_dag_json")] &'a Cid);
     #[derive(Serialize)]
+    #[serde(rename_all = "PascalCase")]
     struct JsonBlockMsgRef<'a> {
-        #[serde(rename = "Header")]
         #[serde(with = "crate::header::json")]
         header: &'a BlockHeader,
-        #[serde(rename = "BlsMessages")]
-        bls_msgs: &'a [JsonCidRef<'a>],
-        #[serde(rename = "SecpkMessages")]
-        secp_msgs: &'a [JsonCidRef<'a>],
+        bls_messages: &'a [JsonCidRef<'a>],
+        secpk_messages: &'a [JsonCidRef<'a>],
     }
 
     /// JSON serialization
@@ -130,13 +128,13 @@ pub mod json {
     {
         JsonBlockMsgRef {
             header: &block.header,
-            bls_msgs: &block
-                .bls_msgs
+            bls_messages: &block
+                .bls_messages
                 .iter()
                 .map(|cid| JsonCidRef(cid))
                 .collect::<Vec<_>>(),
-            secp_msgs: &block
-                .secp_msgs
+            secpk_messages: &block
+                .secpk_messages
                 .iter()
                 .map(|cid| JsonCidRef(cid))
                 .collect::<Vec<_>>(),
@@ -147,14 +145,12 @@ pub mod json {
     #[derive(Deserialize)]
     struct JsonCid(#[serde(with = "cid::ipld_dag_json")] Cid);
     #[derive(Deserialize)]
+    #[serde(rename_all = "PascalCase")]
     struct JsonBlockMsg {
-        #[serde(rename = "Header")]
         #[serde(with = "crate::header::json")]
         header: BlockHeader,
-        #[serde(rename = "BlsMessages")]
-        bls_msgs: Vec<JsonCid>,
-        #[serde(rename = "SecpkMessages")]
-        secp_msgs: Vec<JsonCid>,
+        bls_messages: Vec<JsonCid>,
+        secpk_messages: Vec<JsonCid>,
     }
 
     /// JSON deserialization
@@ -164,13 +160,13 @@ pub mod json {
     {
         let JsonBlockMsg {
             header,
-            bls_msgs,
-            secp_msgs,
+            bls_messages,
+            secpk_messages,
         } = JsonBlockMsg::deserialize(deserializer)?;
         Ok(BlockMsg {
             header,
-            bls_msgs: bls_msgs.into_iter().map(|cid| cid.0).collect(),
-            secp_msgs: secp_msgs.into_iter().map(|cid| cid.0).collect(),
+            bls_messages: bls_messages.into_iter().map(|cid| cid.0).collect(),
+            secpk_messages: secpk_messages.into_iter().map(|cid| cid.0).collect(),
         })
     }
 }

--- a/primitives/block/src/header.rs
+++ b/primitives/block/src/header.rs
@@ -315,21 +315,35 @@ pub mod json {
     where
         D: de::Deserializer<'de>,
     {
-        let header = JsonBlockHeader::deserialize(deserializer)?;
+        let JsonBlockHeader {
+            miner,
+            ticket,
+            epost_proof,
+            parents,
+            parent_weight,
+            height,
+            parent_state_root,
+            parent_message_receipts,
+            messages,
+            bls_aggregate,
+            timestamp,
+            block_sig,
+            fork_signaling,
+        } = JsonBlockHeader::deserialize(deserializer)?;
         Ok(BlockHeader {
-            miner: header.miner,
-            ticket: header.ticket,
-            epost_proof: header.epost_proof,
-            parents: header.parents.into_iter().map(|parent| parent.0).collect(),
-            parent_weight: header.parent_weight,
-            height: header.height,
-            parent_state_root: header.parent_state_root.0,
-            parent_message_receipts: header.parent_message_receipts.0,
-            messages: header.messages.0,
-            bls_aggregate: header.bls_aggregate,
-            timestamp: header.timestamp,
-            block_sig: header.block_sig,
-            fork_signaling: header.fork_signaling,
+            miner,
+            ticket,
+            epost_proof,
+            parents: parents.into_iter().map(|parent| parent.0).collect(),
+            parent_weight,
+            height,
+            parent_state_root: parent_state_root.0,
+            parent_message_receipts: parent_message_receipts.0,
+            messages: messages.0,
+            bls_aggregate,
+            timestamp,
+            block_sig,
+            fork_signaling,
         })
     }
 }

--- a/primitives/block/src/header.rs
+++ b/primitives/block/src/header.rs
@@ -82,7 +82,7 @@ impl<'de> de::Deserialize<'de> for BlockHeader {
 
 /// BlockHeader CBOR serialization/deserialization
 pub mod cbor {
-    use cid::Cid;
+    use cid::{ipld_dag_cbor as cid_cbor, Cid};
     use serde::{de, ser, Deserialize, Serialize};
 
     use plum_address::{address_cbor, Address};
@@ -93,18 +93,16 @@ pub mod cbor {
     use super::BlockHeader;
 
     #[derive(Serialize)]
-    struct CborCidRef<'a>(#[serde(with = "cid::ipld_dag_cbor")] &'a Cid);
-    #[derive(Serialize)]
     struct CborBlockHeaderRef<'a>(
         #[serde(with = "address_cbor")] &'a Address,
         #[serde(with = "ticket_cbor")] &'a Ticket,
         #[serde(with = "epost_proof_cbor")] &'a EPostProof,
-        &'a [CborCidRef<'a>],
+        #[serde(with = "cid_cbor::vec")] &'a [Cid],
         #[serde(with = "bigint_cbor")] &'a BigInt,
         &'a u64,
-        #[serde(with = "cid::ipld_dag_cbor")] &'a Cid,
-        #[serde(with = "cid::ipld_dag_cbor")] &'a Cid,
-        #[serde(with = "cid::ipld_dag_cbor")] &'a Cid,
+        #[serde(with = "cid_cbor")] &'a Cid,
+        #[serde(with = "cid_cbor")] &'a Cid,
+        #[serde(with = "cid_cbor")] &'a Cid,
         #[serde(with = "signature_cbor")] &'a Signature,
         &'a u64,
         #[serde(with = "signature_cbor")] &'a Signature,
@@ -120,11 +118,7 @@ pub mod cbor {
             &header.miner,
             &header.ticket,
             &header.epost_proof,
-            &header
-                .parents
-                .iter()
-                .map(|parent| CborCidRef(parent))
-                .collect::<Vec<_>>(),
+            &header.parents,
             &header.parent_weight,
             &header.height,
             &header.parent_state_root,
@@ -139,18 +133,16 @@ pub mod cbor {
     }
 
     #[derive(Deserialize)]
-    struct CborCid(#[serde(with = "cid::ipld_dag_cbor")] Cid);
-    #[derive(Deserialize)]
     struct CborBlockHeader(
         #[serde(with = "address_cbor")] Address,
         #[serde(with = "ticket_cbor")] Ticket,
         #[serde(with = "epost_proof_cbor")] EPostProof,
-        Vec<CborCid>,
+        #[serde(with = "cid_cbor::vec")] Vec<Cid>,
         #[serde(with = "bigint_cbor")] BigInt,
         u64,
-        #[serde(with = "cid::ipld_dag_cbor")] Cid,
-        #[serde(with = "cid::ipld_dag_cbor")] Cid,
-        #[serde(with = "cid::ipld_dag_cbor")] Cid,
+        #[serde(with = "cid_cbor")] Cid,
+        #[serde(with = "cid_cbor")] Cid,
+        #[serde(with = "cid_cbor")] Cid,
         #[serde(with = "signature_cbor")] Signature,
         u64,
         #[serde(with = "signature_cbor")] Signature,
@@ -181,7 +173,7 @@ pub mod cbor {
             miner,
             ticket,
             epost_proof,
-            parents: parents.into_iter().map(|parent| parent.0).collect(),
+            parents,
             parent_weight,
             height,
             parent_state_root,
@@ -193,11 +185,46 @@ pub mod cbor {
             fork_signaling,
         })
     }
+
+    /// Vec<BlockHeader> CBOR serialization/deserialization.
+    pub mod vec {
+        use super::*;
+
+        #[derive(Serialize)]
+        struct CborBlockHeaderRef<'a>(#[serde(with = "super")] &'a BlockHeader);
+
+        /// CBOR serialization of Vec<BlockHeader>.
+        pub fn serialize<S>(headers: &[BlockHeader], serializer: S) -> Result<S::Ok, S::Error>
+        where
+            S: ser::Serializer,
+        {
+            headers
+                .iter()
+                .map(|header| CborBlockHeaderRef(header))
+                .collect::<Vec<_>>()
+                .serialize(serializer)
+        }
+
+        #[derive(Deserialize)]
+        struct CborBlockHeader(#[serde(with = "super")] BlockHeader);
+
+        /// CBOR deserialization of Vec<BlockHeader>.
+        pub fn deserialize<'de, D>(deserializer: D) -> Result<Vec<BlockHeader>, D::Error>
+        where
+            D: de::Deserializer<'de>,
+        {
+            let headers = <Vec<CborBlockHeader>>::deserialize(deserializer)?;
+            Ok(headers
+                .into_iter()
+                .map(|CborBlockHeader(header)| header)
+                .collect())
+        }
+    }
 }
 
 /// BlockHeader JSON serialization/deserialization
 pub mod json {
-    use cid::Cid;
+    use cid::{ipld_dag_json as cid_json, Cid};
     use serde::{de, ser, Deserialize, Serialize};
 
     use plum_address::{address_json, Address};
@@ -208,40 +235,32 @@ pub mod json {
     use super::BlockHeader;
 
     #[derive(Serialize)]
-    struct JsonCidRef<'a>(#[serde(with = "cid::ipld_dag_json")] &'a Cid);
-    #[derive(Serialize)]
+    #[serde(rename_all = "PascalCase")]
     struct JsonBlockHeaderRef<'a> {
-        #[serde(rename = "Miner")]
         #[serde(with = "address_json")]
         miner: &'a Address,
-        #[serde(rename = "Ticket")]
         #[serde(with = "ticket_json")]
         ticket: &'a Ticket,
         #[serde(rename = "EPostProof")]
         #[serde(with = "epost_proof_json")]
         epost_proof: &'a EPostProof,
-        #[serde(rename = "Parents")]
-        parents: &'a [JsonCidRef<'a>],
-        #[serde(rename = "ParentWeight")]
+        #[serde(with = "cid_json::vec")]
+        parents: &'a [Cid],
         #[serde(with = "bigint_json")]
         parent_weight: &'a BigInt,
-        #[serde(rename = "Height")]
         height: &'a u64,
-        #[serde(rename = "ParentStateRoot")]
-        parent_state_root: &'a JsonCidRef<'a>,
-        #[serde(rename = "ParentMessageReceipts")]
-        parent_message_receipts: &'a JsonCidRef<'a>,
-        #[serde(rename = "Messages")]
-        messages: &'a JsonCidRef<'a>,
+        #[serde(with = "cid_json")]
+        parent_state_root: &'a Cid,
+        #[serde(with = "cid_json")]
+        parent_message_receipts: &'a Cid,
+        #[serde(with = "cid_json")]
+        messages: &'a Cid,
         #[serde(rename = "BLSAggregate")]
         #[serde(with = "signature_json")]
         bls_aggregate: &'a Signature,
-        #[serde(rename = "Timestamp")]
         timestamp: &'a u64,
-        #[serde(rename = "BlockSig")]
         #[serde(with = "signature_json")]
         block_sig: &'a Signature,
-        #[serde(rename = "ForkSignaling")]
         fork_signaling: &'a u64,
     }
 
@@ -254,16 +273,12 @@ pub mod json {
             miner: &header.miner,
             ticket: &header.ticket,
             epost_proof: &header.epost_proof,
-            parents: &header
-                .parents
-                .iter()
-                .map(|parent| JsonCidRef(parent))
-                .collect::<Vec<_>>(),
+            parents: &header.parents,
             parent_weight: &header.parent_weight,
             height: &header.height,
-            parent_state_root: &JsonCidRef(&header.parent_state_root),
-            parent_message_receipts: &JsonCidRef(&header.parent_message_receipts),
-            messages: &JsonCidRef(&header.messages),
+            parent_state_root: &header.parent_state_root,
+            parent_message_receipts: &header.parent_message_receipts,
+            messages: &header.messages,
             bls_aggregate: &header.bls_aggregate,
             timestamp: &header.timestamp,
             block_sig: &header.block_sig,
@@ -273,44 +288,36 @@ pub mod json {
     }
 
     #[derive(Deserialize)]
-    struct JsonCid(#[serde(with = "cid::ipld_dag_json")] Cid);
-    #[derive(Deserialize)]
+    #[serde(rename_all = "PascalCase")]
     struct JsonBlockHeader {
-        #[serde(rename = "Miner")]
         #[serde(with = "address_json")]
         miner: Address,
-        #[serde(rename = "Ticket")]
         #[serde(with = "ticket_json")]
         ticket: Ticket,
         #[serde(rename = "EPostProof")]
         #[serde(with = "epost_proof_json")]
         epost_proof: EPostProof,
-        #[serde(rename = "Parents")]
-        parents: Vec<JsonCid>,
-        #[serde(rename = "ParentWeight")]
+        #[serde(with = "cid_json::vec")]
+        parents: Vec<Cid>,
         #[serde(with = "bigint_json")]
         parent_weight: BigInt,
-        #[serde(rename = "Height")]
         height: u64,
-        #[serde(rename = "ParentStateRoot")]
-        parent_state_root: JsonCid,
-        #[serde(rename = "ParentMessageReceipts")]
-        parent_message_receipts: JsonCid,
-        #[serde(rename = "Messages")]
-        messages: JsonCid,
+        #[serde(with = "cid_json")]
+        parent_state_root: Cid,
+        #[serde(with = "cid_json")]
+        parent_message_receipts: Cid,
+        #[serde(with = "cid_json")]
+        messages: Cid,
         #[serde(rename = "BLSAggregate")]
         #[serde(with = "signature_json")]
         bls_aggregate: Signature,
-        #[serde(rename = "Timestamp")]
         timestamp: u64,
-        #[serde(rename = "BlockSig")]
         #[serde(with = "signature_json")]
         block_sig: Signature,
-        #[serde(rename = "ForkSignaling")]
         fork_signaling: u64,
     }
 
-    /// CBOR deserialization
+    /// JSON deserialization
     pub fn deserialize<'de, D>(deserializer: D) -> Result<BlockHeader, D::Error>
     where
         D: de::Deserializer<'de>,
@@ -334,17 +341,52 @@ pub mod json {
             miner,
             ticket,
             epost_proof,
-            parents: parents.into_iter().map(|parent| parent.0).collect(),
+            parents,
             parent_weight,
             height,
-            parent_state_root: parent_state_root.0,
-            parent_message_receipts: parent_message_receipts.0,
-            messages: messages.0,
+            parent_state_root,
+            parent_message_receipts,
+            messages,
             bls_aggregate,
             timestamp,
             block_sig,
             fork_signaling,
         })
+    }
+
+    /// Vec<BlockHeader> JSON serialization/deserialization.
+    pub mod vec {
+        use super::*;
+
+        #[derive(Serialize)]
+        struct JsonBlockHeaderRef<'a>(#[serde(with = "super")] &'a BlockHeader);
+
+        /// JSON serialization of Vec<BlockHeader>.
+        pub fn serialize<S>(headers: &[BlockHeader], serializer: S) -> Result<S::Ok, S::Error>
+        where
+            S: ser::Serializer,
+        {
+            headers
+                .iter()
+                .map(|header| JsonBlockHeaderRef(header))
+                .collect::<Vec<_>>()
+                .serialize(serializer)
+        }
+
+        #[derive(Deserialize)]
+        struct JsonBlockHeader(#[serde(with = "super")] BlockHeader);
+
+        /// JSON deserialization of Vec<BlockHeader>.
+        pub fn deserialize<'de, D>(deserializer: D) -> Result<Vec<BlockHeader>, D::Error>
+        where
+            D: de::Deserializer<'de>,
+        {
+            let headers = <Vec<JsonBlockHeader>>::deserialize(deserializer)?;
+            Ok(headers
+                .into_iter()
+                .map(|JsonBlockHeader(header)| header)
+                .collect())
+        }
     }
 }
 

--- a/primitives/block/src/msg_meta.rs
+++ b/primitives/block/src/msg_meta.rs
@@ -50,15 +50,15 @@ impl<'de> de::Deserialize<'de> for MsgMeta {
 
 /// MsgMeta CBOR serialization/deserialization
 pub mod cbor {
-    use cid::Cid;
+    use cid::{ipld_dag_cbor as cid_cbor, Cid};
     use serde::{de, ser, Deserialize, Serialize};
 
     use super::MsgMeta;
 
     #[derive(Serialize)]
     struct CborMsgMetaRef<'a>(
-        #[serde(with = "cid::ipld_dag_cbor")] &'a Cid,
-        #[serde(with = "cid::ipld_dag_cbor")] &'a Cid,
+        #[serde(with = "cid_cbor")] &'a Cid,
+        #[serde(with = "cid_cbor")] &'a Cid,
     );
 
     /// CBOR serialization
@@ -71,8 +71,8 @@ pub mod cbor {
 
     #[derive(Deserialize)]
     struct CborMsgMeta(
-        #[serde(with = "cid::ipld_dag_cbor")] Cid,
-        #[serde(with = "cid::ipld_dag_cbor")] Cid,
+        #[serde(with = "cid_cbor")] Cid,
+        #[serde(with = "cid_cbor")] Cid,
     );
 
     /// CBOR deserialization
@@ -87,7 +87,7 @@ pub mod cbor {
 
 /// MsgMeta JSON serialization/deserialization
 pub mod json {
-    use cid::Cid;
+    use cid::{ipld_dag_json as cid_json, Cid};
     use serde::{de, ser, Deserialize, Serialize};
 
     use super::MsgMeta;
@@ -95,10 +95,10 @@ pub mod json {
     #[derive(Serialize)]
     struct JsonMsgMetaRef<'a> {
         #[serde(rename = "BlsMessages")]
-        #[serde(with = "cid::ipld_dag_json")]
+        #[serde(with = "cid_json")]
         bls_msg: &'a Cid,
         #[serde(rename = "SecpkMessages")]
-        #[serde(with = "cid::ipld_dag_json")]
+        #[serde(with = "cid_json")]
         secp_msg: &'a Cid,
     }
 
@@ -117,10 +117,10 @@ pub mod json {
     #[derive(Deserialize)]
     struct JsonMsgMeta {
         #[serde(rename = "BlsMessages")]
-        #[serde(with = "cid::ipld_dag_json")]
+        #[serde(with = "cid_json")]
         bls_msg: Cid,
         #[serde(rename = "SecpkMessages")]
-        #[serde(with = "cid::ipld_dag_json")]
+        #[serde(with = "cid_json")]
         secp_msg: Cid,
     }
 

--- a/primitives/hash/src/lib.rs
+++ b/primitives/hash/src/lib.rs
@@ -6,4 +6,4 @@
 
 mod h256;
 
-pub use self::h256::{option as h256_option, raw as h256_raw, H256};
+pub use self::h256::{cbor as h256_cbor, H256};

--- a/primitives/message/Cargo.toml
+++ b/primitives/message/Cargo.toml
@@ -6,7 +6,6 @@ edition = "2018"
 license = "GPL-3.0"
 
 [dependencies]
-base64 = "0.12"
 cid = { version = "0.4", features = ["impl-serde"] }
 multihash = "0.10"
 serde = { version = "1.0", features = ["derive"] }
@@ -16,6 +15,7 @@ serde_cbor = { version = "0.11.1", features = ["tags"] }
 plum_address = { path = "../address" }
 plum_bigint = { path = "../bigint" }
 plum_crypto = { path = "../../crypto" }
+plum_types = { path = "../types" }
 
 [dev-dependencies]
 serde_json = "1.0"

--- a/primitives/message/src/signed_message.rs
+++ b/primitives/message/src/signed_message.rs
@@ -96,6 +96,41 @@ pub mod cbor {
         let CborSignedMessage(message, signature) = CborSignedMessage::deserialize(deserializer)?;
         Ok(SignedMessage { message, signature })
     }
+
+    /// Vec<SignedMessage> CBOR serialization/deserialization.
+    pub mod vec {
+        use super::*;
+
+        #[derive(Serialize)]
+        struct CborSignedMessageRef<'a>(#[serde(with = "super")] &'a SignedMessage);
+
+        /// CBOR serialization of Vec<SignedMessage>.
+        pub fn serialize<S>(signed_msgs: &[SignedMessage], serializer: S) -> Result<S::Ok, S::Error>
+        where
+            S: ser::Serializer,
+        {
+            signed_msgs
+                .iter()
+                .map(|signed_msg| CborSignedMessageRef(signed_msg))
+                .collect::<Vec<_>>()
+                .serialize(serializer)
+        }
+
+        #[derive(Deserialize)]
+        struct CborSignedMessage(#[serde(with = "super")] SignedMessage);
+
+        /// CBOR deserialization of Vec<SignedMessage>.
+        pub fn deserialize<'de, D>(deserializer: D) -> Result<Vec<SignedMessage>, D::Error>
+        where
+            D: de::Deserializer<'de>,
+        {
+            let signed_msgs = <Vec<CborSignedMessage>>::deserialize(deserializer)?;
+            Ok(signed_msgs
+                .into_iter()
+                .map(|CborSignedMessage(signed_msg)| signed_msg)
+                .collect())
+        }
+    }
 }
 
 /// SignedMessage JSON serialization/deserialization.
@@ -145,5 +180,40 @@ pub mod json {
         let JsonSignedMessage { message, signature } =
             JsonSignedMessage::deserialize(deserializer)?;
         Ok(SignedMessage { message, signature })
+    }
+
+    /// Vec<SignedMessage> JSON serialization/deserialization.
+    pub mod vec {
+        use super::*;
+
+        #[derive(Serialize)]
+        struct JsonSignedMessageRef<'a>(#[serde(with = "super")] &'a SignedMessage);
+
+        /// JSON serialization of Vec<SignedMessage>.
+        pub fn serialize<S>(signed_msgs: &[SignedMessage], serializer: S) -> Result<S::Ok, S::Error>
+        where
+            S: ser::Serializer,
+        {
+            signed_msgs
+                .iter()
+                .map(|signed_msg| JsonSignedMessageRef(signed_msg))
+                .collect::<Vec<_>>()
+                .serialize(serializer)
+        }
+
+        #[derive(Deserialize)]
+        struct JsonSignedMessage(#[serde(with = "super")] SignedMessage);
+
+        /// JSON deserialization of Vec<SignedMessage>.
+        pub fn deserialize<'de, D>(deserializer: D) -> Result<Vec<SignedMessage>, D::Error>
+        where
+            D: de::Deserializer<'de>,
+        {
+            let signed_msgs = <Vec<JsonSignedMessage>>::deserialize(deserializer)?;
+            Ok(signed_msgs
+                .into_iter()
+                .map(|JsonSignedMessage(signed_msg)| signed_msg)
+                .collect())
+        }
     }
 }

--- a/primitives/message/src/unsigned_message.rs
+++ b/primitives/message/src/unsigned_message.rs
@@ -249,16 +249,25 @@ pub mod json {
     where
         D: de::Deserializer<'de>,
     {
-        let unsigned_msg = JsonUnsignedMessage::deserialize(deserializer)?;
+        let JsonUnsignedMessage {
+            to,
+            from,
+            nonce,
+            value,
+            gas_price,
+            gas_limit,
+            method,
+            params,
+        } = JsonUnsignedMessage::deserialize(deserializer)?;
         Ok(UnsignedMessage {
-            to: unsigned_msg.to,
-            from: unsigned_msg.from,
-            nonce: unsigned_msg.nonce,
-            value: unsigned_msg.value,
-            gas_price: unsigned_msg.gas_price,
-            gas_limit: unsigned_msg.gas_limit,
-            method: unsigned_msg.method,
-            params: unsigned_msg.params,
+            to,
+            from,
+            nonce,
+            value,
+            gas_price,
+            gas_limit,
+            method,
+            params,
         })
     }
 

--- a/primitives/message/src/unsigned_message.rs
+++ b/primitives/message/src/unsigned_message.rs
@@ -165,7 +165,8 @@ pub mod json {
         #[serde(with = "bigint_json")]
         gas_limit: &'a BigInt,
         method: &'a u64,
-        params: String,
+        #[serde(with = "plum_types::base64")]
+        params: &'a [u8],
     }
 
     /// JSON serialization.
@@ -181,7 +182,7 @@ pub mod json {
             gas_price: &unsigned_msg.gas_price,
             gas_limit: &unsigned_msg.gas_limit,
             method: &unsigned_msg.method,
-            params: base64::encode(&unsigned_msg.params),
+            params: &unsigned_msg.params,
         }
         .serialize(serializer)
     }
@@ -201,7 +202,8 @@ pub mod json {
         #[serde(with = "bigint_json")]
         gas_limit: BigInt,
         method: u64,
-        params: String,
+        #[serde(with = "plum_types::base64")]
+        params: Vec<u8>,
     }
 
     /// JSON deserialization.
@@ -227,7 +229,7 @@ pub mod json {
             gas_price,
             gas_limit,
             method,
-            params: base64::decode(params).expect("base64 decode shouldn't be fail"),
+            params,
         })
     }
 }

--- a/primitives/message/src/unsigned_message.rs
+++ b/primitives/message/src/unsigned_message.rs
@@ -139,6 +139,44 @@ pub mod cbor {
             params,
         })
     }
+
+    /// Vec<UnsignedMessage> CBOR serialization/deserialization.
+    pub mod vec {
+        use super::*;
+
+        #[derive(Serialize)]
+        struct CborUnsignedMessageRef<'a>(#[serde(with = "super")] &'a UnsignedMessage);
+
+        /// CBOR serialization of Vec<UnsignedMessage>.
+        pub fn serialize<S>(
+            unsigned_msgs: &[UnsignedMessage],
+            serializer: S,
+        ) -> Result<S::Ok, S::Error>
+        where
+            S: ser::Serializer,
+        {
+            unsigned_msgs
+                .iter()
+                .map(|unsigned_msg| CborUnsignedMessageRef(unsigned_msg))
+                .collect::<Vec<_>>()
+                .serialize(serializer)
+        }
+
+        #[derive(Deserialize)]
+        struct CborUnsignedMessage(#[serde(with = "super")] UnsignedMessage);
+
+        /// CBOR deserialization of Vec<UnsignedMessage>.
+        pub fn deserialize<'de, D>(deserializer: D) -> Result<Vec<UnsignedMessage>, D::Error>
+        where
+            D: de::Deserializer<'de>,
+        {
+            let unsigned_msgs = <Vec<CborUnsignedMessage>>::deserialize(deserializer)?;
+            Ok(unsigned_msgs
+                .into_iter()
+                .map(|CborUnsignedMessage(unsigned_msg)| unsigned_msg)
+                .collect())
+        }
+    }
 }
 
 /// UnsignedMessage JSON serialization/deserialization.
@@ -211,26 +249,55 @@ pub mod json {
     where
         D: de::Deserializer<'de>,
     {
-        let JsonUnsignedMessage {
-            to,
-            from,
-            nonce,
-            value,
-            gas_price,
-            gas_limit,
-            method,
-            params,
-        } = JsonUnsignedMessage::deserialize(deserializer)?;
+        let unsigned_msg = JsonUnsignedMessage::deserialize(deserializer)?;
         Ok(UnsignedMessage {
-            to,
-            from,
-            nonce,
-            value,
-            gas_price,
-            gas_limit,
-            method,
-            params,
+            to: unsigned_msg.to,
+            from: unsigned_msg.from,
+            nonce: unsigned_msg.nonce,
+            value: unsigned_msg.value,
+            gas_price: unsigned_msg.gas_price,
+            gas_limit: unsigned_msg.gas_limit,
+            method: unsigned_msg.method,
+            params: unsigned_msg.params,
         })
+    }
+
+    /// Vec<UnsignedMessage> JSON serialization/deserialization.
+    pub mod vec {
+        use super::*;
+
+        #[derive(Serialize)]
+        struct JsonUnsignedMessageRef<'a>(#[serde(with = "super")] &'a UnsignedMessage);
+
+        /// JSON serialization of Vec<UnsignedMessage>.
+        pub fn serialize<S>(
+            unsigned_msgs: &[UnsignedMessage],
+            serializer: S,
+        ) -> Result<S::Ok, S::Error>
+        where
+            S: ser::Serializer,
+        {
+            unsigned_msgs
+                .iter()
+                .map(|unsigned_msg| JsonUnsignedMessageRef(unsigned_msg))
+                .collect::<Vec<_>>()
+                .serialize(serializer)
+        }
+
+        #[derive(Deserialize)]
+        struct JsonUnsignedMessage(#[serde(with = "super")] UnsignedMessage);
+
+        /// JSON deserialization of Vec<UnsignedMessage>.
+        pub fn deserialize<'de, D>(deserializer: D) -> Result<Vec<UnsignedMessage>, D::Error>
+        where
+            D: de::Deserializer<'de>,
+        {
+            let unsigned_msgs = <Vec<JsonUnsignedMessage>>::deserialize(deserializer)?;
+            Ok(unsigned_msgs
+                .into_iter()
+                .map(|JsonUnsignedMessage(unsigned_msg)| unsigned_msg)
+                .collect())
+        }
     }
 }
 

--- a/primitives/ticket/Cargo.toml
+++ b/primitives/ticket/Cargo.toml
@@ -6,9 +6,10 @@ edition = "2018"
 license = "GPL-3.0"
 
 [dependencies]
-base64 = "0.12"
 serde = { version = "1.0", features = ["derive"] }
 serde_bytes = "0.11"
+
+plum_types = { path = "../types" }
 
 [dev-dependencies]
 serde_cbor = "0.11.1"

--- a/primitives/ticket/src/epost_proof.rs
+++ b/primitives/ticket/src/epost_proof.rs
@@ -40,13 +40,10 @@ pub mod cbor {
     use super::{EPostProof, EPostTicket};
 
     #[derive(Serialize)]
-    struct CborEPostTicketRef<'a>(#[serde(with = "crate::epost_ticket::cbor")] &'a EPostTicket);
-
-    #[derive(Serialize)]
     struct CborEPostProofRef<'a>(
         #[serde(with = "serde_bytes")] &'a [u8],
         #[serde(with = "serde_bytes")] &'a [u8],
-        &'a [CborEPostTicketRef<'a>],
+        #[serde(with = "crate::epost_ticket::cbor::vec")] &'a [EPostTicket],
     );
 
     /// CBOR serialization
@@ -57,23 +54,16 @@ pub mod cbor {
         CborEPostProofRef(
             &epost_proof.proof,
             &epost_proof.post_rand,
-            &epost_proof
-                .candidates
-                .iter()
-                .map(|candidates| CborEPostTicketRef(candidates))
-                .collect::<Vec<_>>(),
+            &epost_proof.candidates,
         )
         .serialize(serializer)
     }
 
     #[derive(Deserialize)]
-    struct CborEPostTicket(#[serde(with = "crate::epost_ticket::cbor")] EPostTicket);
-
-    #[derive(Deserialize)]
     struct CborEPostProof(
         #[serde(with = "serde_bytes")] Vec<u8>,
         #[serde(with = "serde_bytes")] Vec<u8>,
-        Vec<CborEPostTicket>,
+        #[serde(with = "crate::epost_ticket::cbor::vec")] Vec<EPostTicket>,
     );
 
     /// CBOR deserialization
@@ -86,10 +76,7 @@ pub mod cbor {
         Ok(EPostProof {
             proof,
             post_rand,
-            candidates: candidates
-                .into_iter()
-                .map(|candidate| candidate.0)
-                .collect(),
+            candidates,
         })
     }
 
@@ -125,16 +112,14 @@ pub mod json {
     use super::{EPostProof, EPostTicket};
 
     #[derive(Serialize)]
-    struct JsonEPostTicketRef<'a>(#[serde(with = "crate::epost_ticket::json")] &'a EPostTicket);
-
-    #[derive(Serialize)]
     #[serde(rename_all = "PascalCase")]
     struct JsonEPostProofRef<'a> {
         #[serde(with = "plum_types::base64")]
         proof: &'a [u8],
         #[serde(with = "plum_types::base64")]
         post_rand: &'a [u8],
-        candidates: &'a [JsonEPostTicketRef<'a>],
+        #[serde(with = "crate::epost_ticket::json::vec")]
+        candidates: &'a [EPostTicket],
     }
 
     /// JSON serialization
@@ -145,17 +130,10 @@ pub mod json {
         JsonEPostProofRef {
             proof: &epost_proof.proof,
             post_rand: &epost_proof.post_rand,
-            candidates: &epost_proof
-                .candidates
-                .iter()
-                .map(|candidate| JsonEPostTicketRef(candidate))
-                .collect::<Vec<_>>(),
+            candidates: &epost_proof.candidates,
         }
         .serialize(serializer)
     }
-
-    #[derive(Deserialize)]
-    struct JsonEPostTicket(#[serde(with = "crate::epost_ticket::json")] EPostTicket);
 
     #[derive(Deserialize)]
     #[serde(rename_all = "PascalCase")]
@@ -164,7 +142,8 @@ pub mod json {
         proof: Vec<u8>,
         #[serde(with = "plum_types::base64")]
         post_rand: Vec<u8>,
-        candidates: Vec<JsonEPostTicket>,
+        #[serde(with = "crate::epost_ticket::json::vec")]
+        candidates: Vec<EPostTicket>,
     }
 
     /// JSON deserialization
@@ -180,10 +159,7 @@ pub mod json {
         Ok(EPostProof {
             proof,
             post_rand,
-            candidates: candidates
-                .into_iter()
-                .map(|candidate| candidate.0)
-                .collect(),
+            candidates,
         })
     }
 

--- a/primitives/tipset/src/key.rs
+++ b/primitives/tipset/src/key.rs
@@ -47,13 +47,13 @@ impl Display for TipsetKey {
 
 /// TipsetKey CBOR serialization/deserialization, need to use `serde_cbor::Serializer` and `serde_cbor::Deserializer`
 pub mod cbor {
-    use cid::Cid;
+    use cid::{ipld_dag_cbor as cid_cbor, Cid};
     use serde::{de, ser, Deserialize, Serialize};
 
     use super::TipsetKey;
 
     #[derive(Serialize)]
-    struct CborCidRef<'a>(#[serde(with = "cid::ipld_dag_cbor")] &'a Cid);
+    struct CborCidRef<'a>(#[serde(with = "cid_cbor")] &'a Cid);
 
     /// CBOR serialization.
     pub fn serialize<S>(key: &TipsetKey, serializer: S) -> Result<S::Ok, S::Error>
@@ -69,7 +69,7 @@ pub mod cbor {
     }
 
     #[derive(Deserialize)]
-    struct CborCid(#[serde(with = "cid::ipld_dag_cbor")] Cid);
+    struct CborCid(#[serde(with = "cid_cbor")] Cid);
 
     /// CBOR deserialization.
     pub fn deserialize<'de, D>(deserializer: D) -> Result<TipsetKey, D::Error>
@@ -85,13 +85,13 @@ pub mod cbor {
 
 /// TipsetKey JSON serialization/deserialization
 pub mod json {
-    use cid::Cid;
+    use cid::{ipld_dag_json as cid_json, Cid};
     use serde::{de, ser, Deserialize, Serialize};
 
     use super::TipsetKey;
 
     #[derive(Serialize)]
-    struct JsonCidRef<'a>(#[serde(with = "cid::ipld_dag_json")] &'a Cid);
+    struct JsonCidRef<'a>(#[serde(with = "cid_json")] &'a Cid);
 
     /// JSON serialization.
     pub fn serialize<S>(key: &TipsetKey, serializer: S) -> Result<S::Ok, S::Error>
@@ -107,7 +107,7 @@ pub mod json {
     }
 
     #[derive(Deserialize)]
-    struct JsonCid(#[serde(with = "cid::ipld_dag_json")] Cid);
+    struct JsonCid(#[serde(with = "cid_json")] Cid);
 
     /// JSON deserialization.
     pub fn deserialize<'de, D>(deserializer: D) -> Result<TipsetKey, D::Error>

--- a/primitives/tipset/src/tipset.rs
+++ b/primitives/tipset/src/tipset.rs
@@ -214,13 +214,12 @@ pub mod json {
     #[derive(Serialize)]
     struct JsonBlockHeaderRef<'a>(#[serde(with = "block_header_json")] &'a BlockHeader);
     #[derive(Serialize)]
+    #[serde(rename_all = "PascalCase")]
     struct JsonTipsetRef<'a> {
         #[serde(rename = "Cids")]
         #[serde(with = "crate::key::json")]
         key: &'a TipsetKey,
-        #[serde(rename = "Blocks")]
         blocks: &'a [JsonBlockHeaderRef<'a>],
-        #[serde(rename = "Height")]
         height: &'a u64,
     }
 
@@ -244,13 +243,12 @@ pub mod json {
     #[derive(Deserialize)]
     struct JsonBlockHeader(#[serde(with = "block_header_json")] BlockHeader);
     #[derive(Deserialize)]
+    #[serde(rename_all = "PascalCase")]
     struct JsonTipset {
         #[serde(rename = "Cids")]
         #[serde(with = "crate::key::json")]
         key: TipsetKey,
-        #[serde(rename = "Blocks")]
         blocks: Vec<JsonBlockHeader>,
-        #[serde(rename = "Height")]
         height: u64,
     }
 

--- a/primitives/types/Cargo.toml
+++ b/primitives/types/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2018"
 license = "GPL-3.0"
 
 [dependencies]
+base64 = "0.12"
 cid = { version = "0.4", features = ["impl-serde"] }
 serde = { version = "1.0", features = ["derive"] }
 

--- a/primitives/types/src/actor.rs
+++ b/primitives/types/src/actor.rs
@@ -38,7 +38,7 @@ impl<'de> de::Deserialize<'de> for Actor {
 
 /// Actor CBOR serialization/deserialization
 pub mod cbor {
-    use cid::{ipld_dag_cbor, Cid};
+    use cid::{ipld_dag_cbor as cid_cbor, Cid};
     use serde::{de, ser, Deserialize, Serialize};
 
     use plum_bigint::{bigint_cbor, BigInt};
@@ -47,8 +47,8 @@ pub mod cbor {
 
     #[derive(Serialize)]
     struct CborActorRef<'a>(
-        #[serde(with = "ipld_dag_cbor")] &'a Cid,
-        #[serde(with = "ipld_dag_cbor")] &'a Cid,
+        #[serde(with = "cid_cbor")] &'a Cid,
+        #[serde(with = "cid_cbor")] &'a Cid,
         &'a u64,
         #[serde(with = "bigint_cbor")] &'a BigInt,
     );
@@ -63,8 +63,8 @@ pub mod cbor {
 
     #[derive(Deserialize)]
     struct CborActor(
-        #[serde(with = "ipld_dag_cbor")] Cid,
-        #[serde(with = "ipld_dag_cbor")] Cid,
+        #[serde(with = "cid_cbor")] Cid,
+        #[serde(with = "cid_cbor")] Cid,
         u64,
         #[serde(with = "bigint_cbor")] BigInt,
     );
@@ -86,7 +86,7 @@ pub mod cbor {
 
 /// Actor JSON serialization/deserialization
 pub mod json {
-    use cid::{ipld_dag_json, Cid};
+    use cid::{ipld_dag_json as cid_json, Cid};
     use serde::{de, ser, Deserialize, Serialize};
 
     use plum_bigint::{bigint_json, BigInt};
@@ -94,10 +94,11 @@ pub mod json {
     use super::Actor;
 
     #[derive(Serialize)]
+    #[serde(rename_all = "PascalCase")]
     struct JsonActorRef<'a> {
-        #[serde(with = "ipld_dag_json")]
+        #[serde(with = "cid_json")]
         code: &'a Cid,
-        #[serde(with = "ipld_dag_json")]
+        #[serde(with = "cid_json")]
         head: &'a Cid,
         nonce: &'a u64,
         #[serde(with = "bigint_json")]
@@ -119,10 +120,11 @@ pub mod json {
     }
 
     #[derive(Deserialize)]
+    #[serde(rename_all = "PascalCase")]
     struct JsonActor {
-        #[serde(with = "ipld_dag_json")]
+        #[serde(with = "cid_json")]
         code: Cid,
-        #[serde(with = "ipld_dag_json")]
+        #[serde(with = "cid_json")]
         head: Cid,
         nonce: u64,
         #[serde(with = "bigint_json")]

--- a/primitives/types/src/base64.rs
+++ b/primitives/types/src/base64.rs
@@ -1,0 +1,22 @@
+// Copyright 2019-2020 PolkaX Authors. Licensed under GPL-3.0.
+
+// Fuck golang std library.
+
+use serde::{de, ser, Deserialize, Serialize};
+
+/// JSON serialization of Vec<u8> using base64.
+pub fn serialize<S>(bytes: &[u8], serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: ser::Serializer,
+{
+    base64::encode(bytes).serialize(serializer)
+}
+
+/// JSON deserialization of Vec<u8> using base64.
+pub fn deserialize<'de, D>(deserializer: D) -> Result<Vec<u8>, D::Error>
+where
+    D: de::Deserializer<'de>,
+{
+    base64::decode(String::deserialize(deserializer)?)
+        .map_err(|err| de::Error::custom(format!("base64 decode error: {}", err)))
+}

--- a/primitives/types/src/lib.rs
+++ b/primitives/types/src/lib.rs
@@ -1,13 +1,17 @@
 // Copyright 2019-2020 PolkaX Authors. Licensed under GPL-3.0.
 
-//!
+//! The Common types and utils of primitives.
 
 #![deny(missing_docs)]
 
-/// Actor with CBOR and JSON serialization/deserialization.
-pub mod actor;
-///
-pub mod chain_epoch;
+mod actor;
+/// JSON serialization/deserialization of Vec<u8> using base64,
+/// in order to be compatible with golang standard library.
+pub mod base64;
+mod chain_epoch;
+
+pub use self::actor::{json as actor_json, Actor};
+pub use self::chain_epoch::{ChainEpoch, EpochDuration, CHAIN_EPOCH_UNDEFINED};
 
 use plum_bigint::BigInt;
 
@@ -20,7 +24,7 @@ pub type TokenAmount = BigInt;
 ///
 pub type PeerId = String;
 ///
-pub type ActorID = u64;
+pub type ActorId = u64;
 ///
 pub type SectorNumber = u64;
 ///

--- a/vm/src/lib.rs
+++ b/vm/src/lib.rs
@@ -6,4 +6,4 @@
 
 mod types;
 
-pub use self::types::{ExecutionResult, json as execution_result_json};
+pub use self::types::{json as execution_result_json, ExecutionResult};

--- a/vm/src/types.rs
+++ b/vm/src/types.rs
@@ -36,34 +36,15 @@ pub mod json {
 
     /// JSON serialization
     pub fn serialize<S>(exe_result: &ExecutionResult, serializer: S) -> Result<S::Ok, S::Error>
-        where
-            S: ser::Serializer,
+    where
+        S: ser::Serializer,
     {
         JsonExecutionResultRef {
             msg: &exe_result.msg,
             msg_receipt: &exe_result.msg_receipt,
             error: &exe_result.error,
         }
-            .serialize(serializer)
-    }
-
-    /// JSON seq serialization
-    pub fn serialize_seq<S>(
-        exe_results: &[ExecutionResult],
-        serializer: S,
-    ) -> Result<S::Ok, S::Error>
-        where
-            S: ser::Serializer,
-    {
-        exe_results
-            .iter()
-            .map(|exe_result| JsonExecutionResultRef {
-                msg: &exe_result.msg,
-                msg_receipt: &exe_result.msg_receipt,
-                error: &exe_result.error,
-            })
-            .collect::<Vec<_>>()
-            .serialize(serializer)
+        .serialize(serializer)
     }
 
     #[derive(Deserialize)]
@@ -79,8 +60,8 @@ pub mod json {
 
     /// JSON deserialization
     pub fn deserialize<'de, D>(deserializer: D) -> Result<ExecutionResult, D::Error>
-        where
-            D: de::Deserializer<'de>,
+    where
+        D: de::Deserializer<'de>,
     {
         let JsonExecutionResult {
             msg,
@@ -94,19 +75,43 @@ pub mod json {
         })
     }
 
-    /// JSON seq deserialization
-    pub fn deserialize_seq<'de, D>(deserializer: D) -> Result<Vec<ExecutionResult>, D::Error>
+    /// Vec<ExecutionResult> JSON serialization/deserialization.
+    pub mod vec {
+        use super::*;
+
+        /// Vec<ExecutionResult> JSON serialization
+        pub fn serialize<S>(
+            exe_results: &[ExecutionResult],
+            serializer: S,
+        ) -> Result<S::Ok, S::Error>
+        where
+            S: ser::Serializer,
+        {
+            exe_results
+                .iter()
+                .map(|exe_result| JsonExecutionResultRef {
+                    msg: &exe_result.msg,
+                    msg_receipt: &exe_result.msg_receipt,
+                    error: &exe_result.error,
+                })
+                .collect::<Vec<_>>()
+                .serialize(serializer)
+        }
+
+        /// Vec<ExecutionResult> JSON deserialization
+        pub fn deserialize<'de, D>(deserializer: D) -> Result<Vec<ExecutionResult>, D::Error>
         where
             D: de::Deserializer<'de>,
-    {
-        let exe_results = <Vec<JsonExecutionResult>>::deserialize(deserializer)?;
-        Ok(exe_results
-            .into_iter()
-            .map(|result| ExecutionResult {
-                msg: result.msg,
-                msg_receipt: result.msg_receipt,
-                error: result.error,
-            })
-            .collect())
+        {
+            let exe_results = <Vec<JsonExecutionResult>>::deserialize(deserializer)?;
+            Ok(exe_results
+                .into_iter()
+                .map(|result| ExecutionResult {
+                    msg: result.msg,
+                    msg_receipt: result.msg_receipt,
+                    error: result.error,
+                })
+                .collect())
+        }
     }
 }

--- a/wallet/Cargo.toml
+++ b/wallet/Cargo.toml
@@ -6,7 +6,6 @@ edition = "2018"
 license = "GPL-3.0"
 
 [dependencies]
-base64 = "0.12"
 bls-signatures = "0.5"
 libsecp256k1 = "0.3"
 parking_lot = "0.10"
@@ -17,3 +16,4 @@ thiserror = "1.0"
 
 plum_address = { path = "../primitives/address" }
 plum_crypto = { path = "../crypto" }
+plum_types = { path = "../primitives/types" }

--- a/wallet/src/keystore/key_info.rs
+++ b/wallet/src/keystore/key_info.rs
@@ -120,13 +120,12 @@ pub mod key_info_json {
     use super::{KeyInfo, KeyType};
 
     #[derive(Serialize)]
+    #[serde(rename_all = "PascalCase")]
     struct JsonKeyInfoRef<'a> {
-        #[serde(rename = "Type")]
         #[serde(with = "super::key_type_json")]
-        ty: &'a KeyType,
-        #[serde(rename = "PrivateKey")]
+        r#type: &'a KeyType,
         #[serde(with = "plum_types::base64")]
-        privkey: &'a [u8],
+        private_key: &'a [u8],
     }
 
     /// JSON serialization
@@ -135,20 +134,19 @@ pub mod key_info_json {
         S: ser::Serializer,
     {
         JsonKeyInfoRef {
-            ty: &key_info.ty,
-            privkey: &key_info.privkey,
+            r#type: &key_info.ty,
+            private_key: &key_info.privkey,
         }
         .serialize(serializer)
     }
 
     #[derive(Deserialize)]
+    #[serde(rename_all = "PascalCase")]
     struct JsonKeyInfo {
-        #[serde(rename = "Type")]
         #[serde(with = "super::key_type_json")]
-        ty: KeyType,
-        #[serde(rename = "PrivateKey")]
+        r#type: KeyType,
         #[serde(with = "plum_types::base64")]
-        privkey: Vec<u8>,
+        private_key: Vec<u8>,
     }
 
     /// JSON deserialization
@@ -158,8 +156,8 @@ pub mod key_info_json {
     {
         let key_info = JsonKeyInfo::deserialize(deserializer)?;
         Ok(KeyInfo {
-            ty: key_info.ty,
-            privkey: key_info.privkey,
+            ty: key_info.r#type,
+            privkey: key_info.private_key,
         })
     }
 }

--- a/wallet/src/keystore/key_info.rs
+++ b/wallet/src/keystore/key_info.rs
@@ -125,7 +125,8 @@ pub mod key_info_json {
         #[serde(with = "super::key_type_json")]
         ty: &'a KeyType,
         #[serde(rename = "PrivateKey")]
-        privkey: String,
+        #[serde(with = "plum_types::base64")]
+        privkey: &'a [u8],
     }
 
     /// JSON serialization
@@ -135,7 +136,7 @@ pub mod key_info_json {
     {
         JsonKeyInfoRef {
             ty: &key_info.ty,
-            privkey: base64::encode(&key_info.privkey),
+            privkey: &key_info.privkey,
         }
         .serialize(serializer)
     }
@@ -146,7 +147,8 @@ pub mod key_info_json {
         #[serde(with = "super::key_type_json")]
         ty: KeyType,
         #[serde(rename = "PrivateKey")]
-        privkey: String,
+        #[serde(with = "plum_types::base64")]
+        privkey: Vec<u8>,
     }
 
     /// JSON deserialization
@@ -157,7 +159,7 @@ pub mod key_info_json {
         let key_info = JsonKeyInfo::deserialize(deserializer)?;
         Ok(KeyInfo {
             ty: key_info.ty,
-            privkey: base64::decode(key_info.privkey).expect("base64 decode shouldn't be fail"),
+            privkey: key_info.privkey,
         })
     }
 }


### PR DESCRIPTION
* Add serialization/deserialization of Vec<u8> using base64, in order to
  be compatible with the golang standard library -- `encoding/json`;
* Refactor cbor serialization/deserializaion of H256;
* Rename ActorID, SectorID to ActorId, SectorId;
* Impl seq serialization/deserialization for some types

Signed-off-by: koushiro <koushiro.cqx@gmail.com>