### PR TITLE
Refactor fc::comm module a bit

### DIFF
--- a/primitives/fc/src/commcid.rs
+++ b/primitives/fc/src/commcid.rs
@@ -59,23 +59,26 @@ pub fn cid_to_piece_commitment_v1(cid: &Cid) -> Result<Commitment, CommCidErr> {
 
 ///
 pub fn cid_to_data_commitment_v1(cid: &Cid) -> Result<Commitment, CommCidErr> {
-    let hash = cid_to_commitment(cid, FilecoinMultihashCode::FcUnsealedV1)?;
-    let mut r = Commitment::default();
-    // hash.digest must be 32 bytes, if not panic here.
-    r.copy_from_slice(hash.digest());
-    Ok(r)
+    cid_to_commitment(cid, FilecoinMultihashCode::FcUnsealedV1)
 }
 
 ///
 pub fn cid_to_replica_commitment_v1(cid: &Cid) -> Result<Commitment, CommCidErr> {
-    let hash = cid_to_commitment(cid, FilecoinMultihashCode::FcSealedV1)?;
-    let mut r = Commitment::default();
-    // hash.digest must be 32 bytes, if not panic here.
-    r.copy_from_slice(hash.digest());
-    Ok(r)
+    cid_to_commitment(cid, FilecoinMultihashCode::FcSealedV1)
 }
 
 fn cid_to_commitment(
+    cid: &Cid,
+    multihash_code: FilecoinMultihashCode,
+) -> Result<Commitment, CommCidErr> {
+    let hash = cid_to_multihash(cid, multihash_code)?;
+    let mut c = Commitment::default();
+    // hash.digest must be 32 bytes, if not panic here.
+    c.copy_from_slice(hash.digest());
+    Ok(c)
+}
+
+fn cid_to_multihash(
     cid: &Cid,
     expect: FilecoinMultihashCode,
 ) -> Result<ExtMultihashRef, CommCidErr> {

--- a/primitives/fc/src/commcid.rs
+++ b/primitives/fc/src/commcid.rs
@@ -53,14 +53,14 @@ fn cid_to_commitment(
 
 fn cid_to_multihash(
     cid: &Cid,
-    expect: FilecoinMultihashCode,
+    expected: FilecoinMultihashCode,
 ) -> Result<ExtMultihashRef, CommCidErr> {
     let hash = cid.hash();
     let code = hash.algorithm();
     match code {
         ExtCode::FL(fl_code) => {
-            if fl_code != expect {
-                Err(CommCidErr::UnexpectedMultihashCode(expect, fl_code))
+            if fl_code != expected {
+                Err(CommCidErr::UnexpectedMultihashCode(expected, fl_code))
             } else {
                 Ok(hash)
             }
@@ -69,34 +69,34 @@ fn cid_to_multihash(
     }
 }
 
-///
+/// Converts a raw commitment to a CID with sealed hash type.
 pub fn replica_commitment_v1_to_cid(commitment: Commitment) -> Cid {
     commitment_to_cid(commitment, FilecoinMultihashCode::FcSealedV1)
         .expect("`commitment_to_cid` must receive `FcSealedV1`")
 }
 
-///
+/// Converts a raw commitment to a CID with unsealed hash type.
 pub fn data_commitment_v1_to_cid(commitment: Commitment) -> Cid {
     commitment_to_cid(commitment, FilecoinMultihashCode::FcUnsealedV1)
         .expect("`commitment_to_cid` must receive `FcUnsealedV1`")
 }
 
-///
+/// Converts a commP to a CID, equivalent to data_commitment_v1_to_cid().
 pub fn piece_commitment_v1_to_cid(commitment: Commitment) -> Cid {
     data_commitment_v1_to_cid(commitment)
 }
 
-///
+/// Extracts the raw commiment from a CID that uses sealed hashing function.
 pub fn cid_to_replica_commitment_v1(cid: &Cid) -> Result<Commitment, CommCidErr> {
     cid_to_commitment(cid, FilecoinMultihashCode::FcSealedV1)
 }
 
-///
+/// Extracts the raw commiment from a CID that uses unsealed hashing function.
 pub fn cid_to_data_commitment_v1(cid: &Cid) -> Result<Commitment, CommCidErr> {
     cid_to_commitment(cid, FilecoinMultihashCode::FcUnsealedV1)
 }
 
-///
+/// Converts a CID to a commP, equivalent to cid_to_data_commitment_v1()
 pub fn cid_to_piece_commitment_v1(cid: &Cid) -> Result<Commitment, CommCidErr> {
     cid_to_data_commitment_v1(cid)
 }

--- a/primitives/fc/src/commcid.rs
+++ b/primitives/fc/src/commcid.rs
@@ -9,7 +9,7 @@ use cid::{
     FilecoinUnsealedV1,
 };
 
-pub type Commitment = [u8; 32];
+type Commitment = [u8; 32];
 
 ///
 pub const FILECOIN_CODEC_TYPE: Codec = Codec::Raw;
@@ -40,7 +40,7 @@ pub fn commitment_to_cid(
 }
 
 /// Extracts the raw data commitment from a CID given the multihash type.
-fn cid_to_commitment(
+pub fn cid_to_commitment(
     cid: &Cid,
     multihash_code: FilecoinMultihashCode,
 ) -> Result<Commitment, CommCidErr> {

--- a/primitives/fc/src/lib.rs
+++ b/primitives/fc/src/lib.rs
@@ -4,9 +4,9 @@
 
 #![deny(missing_docs)]
 
-mod comm;
+mod commcid;
 
-pub use self::comm::{
+pub use self::commcid::{
     cid_to_data_commitment_v1, cid_to_piece_commitment_v1, cid_to_replica_commitment_v1,
     commitment_to_cid, data_commitment_v1_to_cid, piece_commitment_v1_to_cid,
     replica_commitment_v1_to_cid, CommCidErr, FILECOIN_CODEC_TYPE,

--- a/primitives/fc/src/lib.rs
+++ b/primitives/fc/src/lib.rs
@@ -6,11 +6,7 @@
 
 mod commcid;
 
-pub use self::commcid::{
-    cid_to_data_commitment_v1, cid_to_piece_commitment_v1, cid_to_replica_commitment_v1,
-    commitment_to_cid, data_commitment_v1_to_cid, piece_commitment_v1_to_cid,
-    replica_commitment_v1_to_cid, CommCidErr, FILECOIN_CODEC_TYPE,
-};
+pub use self::commcid::*;
 
 use plum_address::{Address, AddressError};
 use plum_types::ActorId;


### PR DESCRIPTION
- Rename `comm.rs` to `commcid.rs`
- Extract new `cid_to_commit()`, rename the previous `cid_to_commit()` to `cid_to_multihash()`.